### PR TITLE
chore(ci): add security scanning compliance for GitHub Team downgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  scan-sast:
+    name: Scan SAST
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read
+    secrets:
+      GH_TOKEN: ${{ secrets.OPENTOFU_GH_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  scan-sca:
+    name: Scan SCA
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read
+
+  scan-secrets:
+    name: Scan Secrets
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,34 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  scan-sast:
+    name: Scan SAST
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read
+    secrets:
+      GH_TOKEN: ${{ secrets.OPENTOFU_GH_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  scan-sca:
+    name: Scan SCA
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read
+
+  scan-secrets:
+    name: Scan Secrets
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@1.0.0
+    permissions:
+      checks: write
+      contents: read

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,106 @@
+{
+  "version": "1.2.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-02-19T19:59:07Z"
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=Avodah-Inc_opentofu-aws-control_tower_account_factory
+sonar.projectName=Opentofu Aws Control_tower_account_factory
+sonar.organization=avodah-inc
+sonar.sources=src
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Security Scanning Compliance

This PR adds required security scanning workflows to comply with GitHub Team plan requirements (March 2026 downgrade).

### Changes
- ✅ Added/Updated CI workflow with SCA, SAST, Secret scanning
- ✅ Added/Updated PR workflow with SCA, SAST, Secret scanning
- ✅ Added sonar-project.properties configuration
- ✅ Added .secrets.baseline for secret detection

### Required Secrets
Ensure the following GitHub secrets are configured:
- `OPENTOFU_GH_TOKEN`
- `SONAR_TOKEN`

### Testing
- [ ] Verify workflows run successfully on this PR
- [ ] Review SonarQube scan results
- [ ] Confirm no false positive secrets detected

### Documentation
- [GitHub Security Compliance Plan](https://wiki.avodah.com/posts/git-hub-security-and-compliance-plan-7h3u6eka)
- [Compliance Tools Repository](https://github.com/Avodah-Inc/github-security-compliance)