### PR TITLE
chore(ci): Pin all action references to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scan-sast:
     name: Scan SAST
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read
@@ -21,14 +21,14 @@ jobs:
 
   scan-sca:
     name: Scan SCA
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read
 
   scan-secrets:
     name: Scan Secrets
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scan-sast:
     name: Scan SAST
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read
@@ -21,14 +21,14 @@ jobs:
 
   scan-sca:
     name: Scan SCA
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read
 
   scan-secrets:
     name: Scan Secrets
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
     permissions:
       checks: write
       contents: read


### PR DESCRIPTION
Pin all third-party actions and internal reusable workflow references to immutable commit SHAs. Prepares for enabling the GitHub org policy "Require actions to be pinned to a full-length commit SHA".

See: [CLI-1320](https://linear.app/avodah-inc/issue/CLI-1320) | Related: [CLI-1314](https://linear.app/avodah-inc/issue/CLI-1314)