### PR TITLE
chore(ci): update github-actions to 4.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,31 @@ permissions:
 jobs:
   scan-sast:
     name: Scan SAST
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+    secrets:
+      GH_TOKEN: ${{ secrets.OPENTOFU_GH_TOKEN }}
+      LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
+      LINEAR_CLIENT_SECRET: ${{ secrets.LINEAR_CLIENT_SECRET }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  scan-sca:
+    name: Scan SCA
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
     permissions:
       checks: write
       contents: read
     secrets:
       GH_TOKEN: ${{ secrets.OPENTOFU_GH_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  scan-sca:
-    name: Scan SCA
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
-    permissions:
-      checks: write
-      contents: read
+      LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
+      LINEAR_CLIENT_SECRET: ${{ secrets.LINEAR_CLIENT_SECRET }}
 
   scan-secrets:
     name: Scan Secrets
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   scan-sast:
     name: Scan SAST
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sast.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/pr-scan-sast.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
     permissions:
       checks: write
       contents: read
@@ -21,14 +21,14 @@ jobs:
 
   scan-sca:
     name: Scan SCA
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-sca.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/pr-scan-sca.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
     permissions:
       checks: write
       contents: read
 
   scan-secrets:
     name: Scan Secrets
-    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@c3810d33d35f4469cc222e98bf83fc9ddcc34d9b # 1.0.0
+    uses: Avodah-Inc/github-actions/.github/workflows/scan-secrets.yml@7a11234f8530d810e1ad04b67cd809dca6e316ae # 4.12.0
     permissions:
       checks: write
       contents: read


### PR DESCRIPTION
Update github-actions reusable workflow references to 4.12.0 (SHA `7a11234`).

Includes:
- `--ignore-scripts` hardening for npm/pnpm installs
- `npm audit signatures` verification
- scan-secrets action pin fix
- pr-provision-gcp git config fix
- Pin configure-multiple-aws-roles to Avodah-Inc fork
- Use pr-scan-sast and pr-scan-sca for PR workflows
- Add LINEAR_CLIENT_ID and LINEAR_CLIENT_SECRET secrets to scan-sast and scan-sca
- Add actions:read permission to scan-sast
- Replace pre-commit/action composite with inline steps (where applicable)

See: [CLI-1348](https://linear.app/avodah-inc/issue/CLI-1348)