### PR TITLE
fix(lambda-layer): Restore account_provisioning_framework module

### DIFF
--- a/sources/aft-lambda-layer/aft_common/account_provisioning_framework.py
+++ b/sources/aft-lambda-layer/aft_common/account_provisioning_framework.py
@@ -3,455 +3,278 @@
 #
 import json
 import logging
-import uuid
-from datetime import datetime
-from functools import cached_property, partial
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
+import time
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Dict, List
 
+import aft_common.aft_utils as utils
 import aft_common.constants
-import aft_common.service_catalog
 import aft_common.ssm
-from aft_common import aft_utils as utils
-from aft_common import ddb, sqs
-from aft_common.account_provisioning_framework import ProvisionRoles
-from aft_common.aft_types import AftInvokeAccountCustomizationPayload
+from aft_common import ddb
+from aft_common.aft_utils import sanitize_input_for_logging
 from aft_common.auth import AuthClient
-from aft_common.exceptions import (
-    NoAccountFactoryPortfolioFound,
-    ServiceRoleNotAssociated,
-)
 from aft_common.organizations import OrganizationsAgent
 from boto3.session import Session
+from botocore.exceptions import ClientError
 
 if TYPE_CHECKING:
-    from mypy_boto3_dynamodb.type_defs import PutItemOutputTypeDef
-    from mypy_boto3_servicecatalog import ServiceCatalogClient
-    from mypy_boto3_servicecatalog.type_defs import (
-        ProvisionedProductAttributeTypeDef,
-        ProvisionedProductDetailTypeDef,
-        ProvisioningParameterTypeDef,
-        ProvisionProductOutputTypeDef,
-        UpdateProvisioningParameterTypeDef,
-    )
+    from mypy_boto3_dynamodb.type_defs import PutItemOutputTableTypeDef
+    from mypy_boto3_iam import IAMClient, IAMServiceResource
+    from mypy_boto3_organizations.type_defs import TagTypeDef
 else:
-    SearchProvisionedProductsOutputTypeDef = object
-    PutItemOutputTypeDef = object
-    ProvisioningParameterTypeDef = object
-    ProvisionedProductDetailTypeDef = object
-    ProvisionProductOutputTypeDef = object
-    UpdateProvisioningParameterTypeDef = object
-    ProvisionedProductAttributeTypeDef = object
-    ServiceCatalogClient = object
+    PutItemOutputTableTypeDef = object
+    IAMClient = object
+    CreateRoleResponseTypeDef = object
+    IAMServiceResource = object
+    TagTypeDef = object
 
 
 logger = logging.getLogger("aft")
 
 
-def insert_msg_into_acc_req_queue(
-    event_record: Dict[Any, Any], new_account: bool, session: Session
-) -> None:
-    sqs_queue = aft_common.ssm.get_ssm_parameter_value(
-        session, aft_common.constants.SSM_PARAM_ACCOUNT_REQUEST_QUEUE
-    )
-    sqs_queue = sqs.build_sqs_url(session=session, queue_name=sqs_queue)
-    message = build_sqs_message(record=event_record, new_account=new_account)
-    sqs.send_sqs_message(session=session, sqs_url=sqs_queue, message=message)
+AFT_EXEC_ROLE = "AWSAFTExecution"
 
 
-def control_tower_param_changed(record: Dict[str, Any]) -> bool:
-    if record["eventName"] == "MODIFY":
-        old_image = ddb.unmarshal_ddb_item(record["dynamodb"]["OldImage"])[
-            "control_tower_parameters"
-        ]
-        new_image = ddb.unmarshal_ddb_item(record["dynamodb"]["NewImage"])[
-            "control_tower_parameters"
-        ]
+class ProvisionRoles:
+    SERVICE_ROLE_NAME = "AWSAFTService"
+    EXECUTION_ROLE_NAME = "AWSAFTExecution"
 
-        if old_image != new_image:
-            return True
-    return False
+    def __init__(self, auth: AuthClient, account_id: str) -> None:
+        self.auth = auth
+        self.target_account_id = account_id
 
+        temp_session = self.auth.get_ct_management_session()
+        self.partition = utils.get_aws_partition(temp_session)
 
-def build_sqs_message(record: Dict[str, Any], new_account: bool) -> Dict[str, Any]:
-    logger.info("Building SQS Message - ")
-    message = {}
-    operation = "ADD" if new_account else "UPDATE"
+        self.ADMINISTRATOR_ACCESS_MANAGED_POLICY_ARN = (
+            f"arn:{self.partition}:iam::aws:policy/AdministratorAccess"
+        )
 
-    new_image = ddb.unmarshal_ddb_item(record["dynamodb"]["NewImage"])
-    message["operation"] = operation
-    message["control_tower_parameters"] = new_image["control_tower_parameters"]
-
-    if record["eventName"] == "MODIFY":
-        old_image = ddb.unmarshal_ddb_item(record["dynamodb"]["OldImage"])
-        message["old_control_tower_parameters"] = old_image["control_tower_parameters"]
-
-    logger.info(utils.sanitize_input_for_logging(message))
-    return message
-
-
-def build_aft_account_provisioning_framework_event(
-    record: Dict[str, Any]
-) -> Dict[str, Any]:
-    account_request = ddb.unmarshal_ddb_item(record["dynamodb"]["NewImage"])
-    aft_account_provisioning_framework_event = {
-        "account_request": account_request,
-        "control_tower_event": {},
-    }
-    logger.info(utils.sanitize_input_for_logging(aft_account_provisioning_framework_event))
-    return aft_account_provisioning_framework_event
-
-
-def put_audit_record(
-    session: Session, table: str, image: Dict[str, Any], event_name: str
-) -> PutItemOutputTypeDef:
-    dynamodb = session.client("dynamodb")
-    item = image
-    datetime_format = "%Y-%m-%dT%H:%M:%S.%f"
-    current_time = datetime.now().strftime(datetime_format)
-    item["timestamp"] = {"S": current_time}
-    item["ddb_event_name"] = {"S": event_name}
-    logger.info("Inserting item into " + utils.sanitize_input_for_logging(table) + " table: " + utils.sanitize_input_for_logging(item))
-    response = dynamodb.put_item(TableName=table, Item=item)
-    sanitized_response = utils.sanitize_input_for_logging(response)
-    logger.info(sanitized_response)
-    return response
-
-
-def account_name_or_email_in_use(
-    ct_management_session: Session, account_name: str, account_email: str
-) -> bool:
-    orgs = ct_management_session.client(
-        "organizations", config=utils.get_high_retry_botoconfig()
-    )
-    paginator = orgs.get_paginator("list_accounts")
-    for page in paginator.paginate():
-        for account in page["Accounts"]:
-            if account_name == account["Name"]:
-                logger.error(
-                    f"Account Name: {account_name} already used in Organizations"
-                )
-                return True
-            if utils.emails_are_equal(account_email, account["Email"]):
-                logger.error(
-                    f"Account Email: {account_email} already used in Organizations"
-                )
-                return True
-
-    return False
-
-
-def new_ct_request_is_valid(session: Session, request: Dict[str, Any]) -> bool:
-    ct_parameters = request["control_tower_parameters"]
-    return not account_name_or_email_in_use(
-        ct_management_session=session,
-        account_name=ct_parameters["AccountName"],
-        account_email=ct_parameters["AccountEmail"],
-    )
-
-
-def modify_ct_request_is_valid(request: Dict[str, Any]) -> bool:
-    old_ct_parameters = request.get("old_control_tower_parameters", {})
-    new_ct_parameters = request["control_tower_parameters"]
-
-    for param_name in old_ct_parameters.keys():
-        if param_name != "ManagedOrganizationalUnit":
-            if old_ct_parameters[param_name] != new_ct_parameters[param_name]:
-                logger.error(
-                    f"Control Tower parameter {utils.sanitize_input_for_logging(param_name)} cannot be modified"
-                )
-                return False
-    return True
-
-
-def add_header(request: Any, **kwargs: Any) -> None:
-    request.headers.add_header(
-        "User-Agent", "account-factory-terraform-" + kwargs["version"]
-    )
-
-
-def create_provisioned_product_name(account_name: str) -> str:
-    """
-    Replaces all space characters in an Account Name with hyphens,
-    also removes all trailing and leading whitespace
-    """
-    return account_name.strip().replace(" ", "-")
-
-
-def create_new_account(
-    session: Session, ct_management_session: Session, request: Dict[str, Any]
-) -> ProvisionProductOutputTypeDef:
-    client = ct_management_session.client("servicecatalog")
-    event_system = client.meta.events
-
-    aft_version = aft_common.ssm.get_ssm_parameter_value(
-        session, aft_common.constants.SSM_PARAM_ACCOUNT_AFT_VERSION
-    )
-    header_with_aft_version = partial(add_header, version=aft_version)
-    event_system.register_first("before-sign.*.*", header_with_aft_version)
-
-    provisioning_parameters = []
-
-    for k, v in request["control_tower_parameters"].items():
-        provisioning_parameters.append({"Key": k, "Value": v})
-
-    logger.info(
-        "Creating new account leveraging parameters: "
-        + utils.sanitize_input_for_logging(str(provisioning_parameters))
-    )
-    provisioned_product_name = create_provisioned_product_name(
-        account_name=request["control_tower_parameters"]["AccountName"]
-    )
-    response = client.provision_product(
-        ProductId=aft_common.service_catalog.get_ct_product_id(
-            session, ct_management_session
-        ),
-        ProvisioningArtifactId=aft_common.service_catalog.get_ct_provisioning_artifact_id(
-            session, ct_management_session
-        ),
-        ProvisionedProductName=provisioned_product_name,
-        ProvisioningParameters=cast(
-            Sequence[ProvisioningParameterTypeDef], provisioning_parameters
-        ),
-        ProvisionToken=str(uuid.uuid1()),
-    )
-    sanitized_response = utils.sanitize_input_for_logging(response)
-    logger.info(sanitized_response)
-    return response
-
-
-def update_existing_account(
-    session: Session, ct_management_session: Session, request: Dict[str, Any]
-) -> None:
-    client = ct_management_session.client("servicecatalog")
-    event_system = client.meta.events
-
-    aft_version = aft_common.ssm.get_ssm_parameter_value(
-        session, aft_common.constants.SSM_PARAM_ACCOUNT_AFT_VERSION
-    )
-    header_with_aft_version = partial(add_header, version=aft_version)
-    event_system.register_first("before-sign.*.*", header_with_aft_version)
-
-    provisioning_parameters: List[UpdateProvisioningParameterTypeDef] = []
-    for k, v in request["control_tower_parameters"].items():
-        provisioning_parameters.append({"Key": k, "Value": v})
-
-    control_tower_email_parameter = request["control_tower_parameters"]["AccountEmail"]
-    target_product: Optional[ProvisionedProductAttributeTypeDef] = None
-    for batch in aft_common.service_catalog.get_healthy_ct_product_batch(
-        ct_management_session=ct_management_session
-    ):
-        for product in batch:
-            product_outputs_response = client.get_provisioned_product_outputs(
-                ProvisionedProductId=product["Id"],
-                OutputKeys=[
-                    "AccountEmail",
+    def generate_aft_trust_policy(self) -> str:
+        return json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": [
+                                # TODO: Do we still need role/AWSAFTAdmin
+                                f"arn:{self.partition}:iam::{self.auth.aft_management_account_id}:role/AWSAFTAdmin",
+                                f"arn:{self.partition}:sts::{self.auth.aft_management_account_id}:assumed-role/AWSAFTAdmin/AWSAFT-Session",
+                            ]
+                        },
+                        "Action": "sts:AssumeRole",
+                    }
                 ],
-            )
-            provisioned_product_email = product_outputs_response["Outputs"][0][
-                "OutputValue"
-            ]
-
-            if utils.emails_are_equal(
-                provisioned_product_email, control_tower_email_parameter
-            ):
-                target_product = product
-                break
-
-    if target_product is None:
-        raise Exception(
-            f"No healthy provisioned product found for {control_tower_email_parameter}"
+            }
         )
 
-    # check to see if the product still exists and is still active
-    if aft_common.service_catalog.ct_provisioning_artifact_is_active(
-        session=session,
-        ct_management_session=ct_management_session,
-        artifact_id=target_product["ProvisioningArtifactId"],
-    ):
-        target_provisioning_artifact_id = target_product["ProvisioningArtifactId"]
-    else:
-        target_provisioning_artifact_id = (
-            aft_common.service_catalog.get_ct_provisioning_artifact_id(
-                session, ct_management_session
-            )
-        )
-
-    logger.info(
-        "Modifying existing account leveraging parameters: "
-        + utils.sanitize_input_for_logging(str(provisioning_parameters))
-        + " with provisioned product ID "
-        + target_product["Id"]
-    )
-    update_response = client.update_provisioned_product(
-        ProvisionedProductId=target_product["Id"],
-        ProductId=aft_common.service_catalog.get_ct_product_id(
-            session, ct_management_session
-        ),
-        ProvisioningArtifactId=target_provisioning_artifact_id,
-        ProvisioningParameters=provisioning_parameters,
-        UpdateToken=str(uuid.uuid1()),
-    )
-    logger.info(utils.sanitize_input_for_logging(update_response))
-
-
-def get_account_request_record(
-    aft_management_session: Session, request_table_id: str
-) -> Dict[str, Any]:
-    table_name = aft_common.ssm.get_ssm_parameter_value(
-        aft_management_session, aft_common.constants.SSM_PARAM_AFT_DDB_REQ_TABLE
-    )
-    logger.info(
-        "Getting record for id " + request_table_id + " in DDB table " + table_name
-    )
-    item = ddb.get_ddb_item(
-        session=aft_management_session,
-        table_name=table_name,
-        primary_key={"id": request_table_id},
-    )
-    if item:
-        logger.info("Record found")
-        logger.info(utils.sanitize_input_for_logging(item))
-        return item
-    else:
-        raise Exception(f"Account {request_table_id}  not found in {table_name}")
-
-
-def build_account_customization_payload(
-    ct_management_session: Session,
-    account_id: str,
-    account_request: Dict[str, Any],
-    control_tower_event: Optional[Dict[str, Any]],
-) -> AftInvokeAccountCustomizationPayload:
-    orgs_agent = OrganizationsAgent(ct_management_session)
-
-    # convert ddb strings into proper data type
-    account_request["account_tags"] = json.loads(account_request["account_tags"])
-    account_info = orgs_agent.get_aft_account_info(account_id=account_id)
-
-    if control_tower_event is None:
-        control_tower_event = {}
-
-    account_customization_payload: AftInvokeAccountCustomizationPayload = {
-        "account_info": {"account": account_info},
-        # Unused by AFT but kept for aft-account-provisioning-customizations backwards compatibility
-        "control_tower_event": control_tower_event,
-        "account_request": account_request,
-        "account_provisioning": {"run_create_pipeline": "true"},
-        "customization_request_id": str(uuid.uuid4()),
-    }
-
-    return account_customization_payload
-
-
-class AccountRequest:
-    ACCOUNT_FACTORY_PORTFOLIO_NAME = "AWS Control Tower Account Factory Portfolio"
-
-    def __init__(self, auth: AuthClient) -> None:
-        self.ct_management_session = auth.get_ct_management_session(
+    def _deploy_role_in_target_account(
+        self, role_name: str, trust_policy: str, policy_arn: str
+    ) -> None:
+        """
+        Since we're creating the AFT roles in the account, we must assume
+        AWSControlTowerExecution as the target role. Since this role only
+        trusts federation from the CT Management account, we pass a hub session
+        that has already been federated into the CT Management account
+        """
+        ct_mgmt_session = self.auth.get_ct_management_session(
             role_name=ProvisionRoles.SERVICE_ROLE_NAME
         )
-        self.ct_management_account_id = auth.get_account_id_from_session(
-            session=self.ct_management_session
-        )
-        self.aft_management_session = auth.get_aft_management_session()
-        self.account_factory_product_id = aft_common.service_catalog.get_ct_product_id(
-            session=self.aft_management_session,
-            ct_management_session=self.ct_management_session,
-        )
-
-        self.partition = utils.get_aws_partition(self.ct_management_session)
-
-    @property
-    def service_role_arn(self) -> str:
-        return f"arn:{self.partition}:iam::{self.ct_management_account_id}:role/{ProvisionRoles.SERVICE_ROLE_NAME}"
-
-    @cached_property
-    def account_factory_portfolio_id(self) -> str:
-        """
-        Paginates through all portfolios and returns the ID of the CT Account Factory Portfolio
-        if it exists, raises exception if not found
-        """
-        client: ServiceCatalogClient = self.ct_management_session.client(
-            "servicecatalog", config=utils.get_high_retry_botoconfig()
-        )
-        paginator = client.get_paginator("list_portfolios")
-        for response in paginator.paginate():
-            for portfolio in response["PortfolioDetails"]:
-                if (
-                    portfolio["DisplayName"]
-                    == AccountRequest.ACCOUNT_FACTORY_PORTFOLIO_NAME
-                ):
-                    return portfolio["Id"]
-
-        raise NoAccountFactoryPortfolioFound(
-            f"No Portfolio ID found for {AccountRequest.ACCOUNT_FACTORY_PORTFOLIO_NAME}"
-        )
-
-    def associate_aft_service_role_with_account_factory(self) -> None:
-        """
-        Associates the AWSAFTService role with the Control Tower Account Factory Service Catalog portfolio
-        """
-        client = self.ct_management_session.client("servicecatalog")
-        aft_service_role_arn = f"arn:{self.partition}:iam::{self.ct_management_account_id}:role/{ProvisionRoles.SERVICE_ROLE_NAME}"
-        client.associate_principal_with_portfolio(
-            PortfolioId=self.account_factory_portfolio_id,
-            PrincipalARN=aft_service_role_arn,
-            PrincipalType="IAM",
-        )
-
-    def validate_service_role_associated_with_account_factory(self) -> None:
-        if not self.service_role_associated_with_account_factory():
-            raise ServiceRoleNotAssociated(
-                f"{ProvisionRoles.SERVICE_ROLE_NAME} Role not associated with portfolio {self.account_factory_portfolio_id}"
+        ct_mgmt_acc_id = ct_mgmt_session.client("sts").get_caller_identity()["Account"]
+        if self.target_account_id == ct_mgmt_acc_id:
+            target_account_session = ct_mgmt_session
+        else:
+            target_account_session = self.auth.get_target_account_session(
+                account_id=self.target_account_id,
+                hub_session=ct_mgmt_session,
+                role_name=AuthClient.CONTROL_TOWER_EXECUTION_ROLE_NAME,
             )
-
-    def service_role_associated_with_account_factory(self) -> bool:
-        client = self.ct_management_session.client(
-            "servicecatalog", config=utils.get_high_retry_botoconfig()
+        self._put_role(
+            target_account_session=target_account_session,
+            role_name=role_name,
+            trust_policy=trust_policy,
         )
-        paginator = client.get_paginator("list_principals_for_portfolio")
-        for response in paginator.paginate(
-            PortfolioId=self.account_factory_portfolio_id
-        ):
-            if self.service_role_arn in [
-                principal["PrincipalARN"] for principal in response["Principals"]
-            ]:
-                return True
-        return False
-
-    def provisioning_threshold_reached(self, threshold: int) -> bool:
-        client: ServiceCatalogClient = self.ct_management_session.client(
-            "servicecatalog", config=utils.get_high_retry_botoconfig()
-        )
-        logger.info("Checking for account provisioning in progress")
-
-        response = client.scan_provisioned_products(
-            AccessLevelFilter={"Key": "Account", "Value": "self"},
-        )
-        pps = response["ProvisionedProducts"]
-        while "NextPageToken" in response:
-            response = client.scan_provisioned_products(
-                AccessLevelFilter={"Key": "Account", "Value": "self"},
-                PageToken=response["NextPageToken"],
-            )
-            pps.extend(response["ProvisionedProducts"])
-
-        return self.products_in_progress_at_threshold(
-            threshold=threshold, provisioned_products=pps
+        self._put_policy_on_role(
+            target_account_session=target_account_session,
+            role_name=role_name,
+            policy_arn=policy_arn,
         )
 
-    def products_in_progress_at_threshold(
+    def _put_role(
         self,
-        threshold: int,
-        provisioned_products: List[ProvisionedProductDetailTypeDef],
+        target_account_session: Session,
+        role_name: str,
+        trust_policy: str,
+        max_attempts: int = 20,
+        delay: int = 5,
+    ) -> None:
+        client: IAMClient = target_account_session.client("iam")
+        if self.role_exists(
+            role_name=role_name, target_account_session=target_account_session
+        ):
+            client.update_assume_role_policy(
+                RoleName=role_name, PolicyDocument=trust_policy
+            )
+        else:
+            client.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument=trust_policy,
+                Description="Role for use with Account Factory for Terraform",
+                MaxSessionDuration=3600,
+                Tags=[{"Key": "managed_by", "Value": "AFT"}],
+            )
+            waiter = client.get_waiter("role_exists")
+            waiter.wait(
+                RoleName=role_name,
+                WaiterConfig={"Delay": delay, "MaxAttempts": max_attempts},
+            )
+
+    @staticmethod
+    def role_exists(role_name: str, target_account_session: Session) -> bool:
+        client: IAMClient = target_account_session.client("iam")
+        try:
+            client.get_role(RoleName=role_name)
+            return True
+
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "NoSuchEntity":
+                return False
+            raise
+
+    def _put_policy_on_role(
+        self,
+        target_account_session: Session,
+        role_name: str,
+        policy_arn: str,
+        delay: int = 5,
+        timeout_in_mins: int = 1,
+    ) -> None:
+        if not self.role_policy_is_attached(
+            role_name=role_name,
+            policy_arn=policy_arn,
+            target_account_session=target_account_session,
+        ):
+            resource: IAMServiceResource = target_account_session.resource("iam")
+            role = resource.Role(role_name)
+            role.attach_policy(PolicyArn=policy_arn)
+            timeout = datetime.utcnow() + timedelta(minutes=timeout_in_mins)
+            while datetime.utcnow() < timeout:
+                time.sleep(delay)
+                if self.role_policy_is_attached(
+                    role_name=role_name,
+                    policy_arn=policy_arn,
+                    target_account_session=target_account_session,
+                ):
+                    return None
+        return None
+
+    @staticmethod
+    def role_policy_is_attached(
+        role_name: str, policy_arn: str, target_account_session: Session
     ) -> bool:
-        in_progress_count = 0
+        logger.info(f"Determining if {policy_arn} is attached to {role_name}")
+        resource: IAMServiceResource = target_account_session.resource("iam")
+        role = resource.Role(role_name)
+        policy_iterator = role.attached_policies.all()
+        policy_arns = [policy.arn for policy in policy_iterator]
+        attached = policy_arn in policy_arns
+        logger.info(
+            f"{policy_arn} is {'attached' if attached else 'detached'} to {role_name}"
+        )
+        return attached
 
-        for product in provisioned_products:
-            if product["ProductId"] != self.account_factory_product_id:
-                continue
-            logger.info("Identified CT Product - " + utils.sanitize_input_for_logging(product["Id"]))
-            if product["Status"] in ["UNDER_CHANGE", "PLAN_IN_PROGRESS"]:
-                in_progress_count += 1
+    def _ensure_role_can_be_assumed(
+        self, role_name: str, timeout_in_mins: int = 1, delay: int = 5
+    ) -> None:
+        timeout = datetime.utcnow() + timedelta(minutes=timeout_in_mins)
+        while datetime.utcnow() < timeout:
+            if self._can_assume_role(role_name=role_name):
+                return None
+            time.sleep(delay)
+        raise TimeoutError(
+            f"Could not assume role {role_name} within {timeout_in_mins} minutes"
+        )
 
-        return in_progress_count >= threshold
+    def _can_assume_role(self, role_name: str) -> bool:
+        try:
+            self.auth.get_target_account_session(
+                account_id=self.target_account_id, role_name=role_name
+            )
+            return True
+        except ClientError:
+            return False
+
+    def deploy_aws_aft_roles(self) -> None:
+        trust_policy = self.generate_aft_trust_policy()
+
+        aft_role_names = [
+            ProvisionRoles.SERVICE_ROLE_NAME,
+            ProvisionRoles.EXECUTION_ROLE_NAME,
+        ]
+
+        logger.info(f"Deploying roles {', '.join(aft_role_names)}")
+        for role_name in aft_role_names:
+            self._deploy_role_in_target_account(
+                role_name=role_name,
+                trust_policy=trust_policy,
+                policy_arn=self.ADMINISTRATOR_ACCESS_MANAGED_POLICY_ARN,
+            )
+            logger.info(f"Deployed {role_name} role")
+
+        for role_name in aft_role_names:
+            self._ensure_role_can_be_assumed(role_name=role_name)
+            logger.info(f"Can assume {role_name} role")
+
+        # Guard for IAM eventual consistency
+        time.sleep(65)
+
+
+# From persist-metadata Lambda
+def persist_metadata(
+    payload: Dict[str, Any], account_info: Dict[str, str], session: Session
+) -> PutItemOutputTableTypeDef:
+    account_tags = payload["account_request"]["account_tags"]
+    account_customizations_name = payload["account_request"][
+        "account_customizations_name"
+    ]
+    metadata_table_name = aft_common.ssm.get_ssm_parameter_value(
+        session, aft_common.constants.SSM_PARAM_AFT_DDB_META_TABLE
+    )
+
+    item = {
+        "id": account_info["id"],
+        "email": account_info["email"],
+        "account_name": account_info["name"],
+        "account_creation_time": account_info["joined_date"],
+        "account_status": account_info["status"],
+        "account_level_tags": account_tags,
+        "account_customizations_name": account_customizations_name,
+        "parent_ou": account_info["parent_id"],
+        "vcs_information": {},
+        "terraform_workspace": {},
+    }
+
+    logger.info("Writing item to " + metadata_table_name)
+    logger.info(item)
+
+    response = ddb.put_ddb_item(session, metadata_table_name, item)
+    sanitized_response = sanitize_input_for_logging(response)
+    logger.info(sanitized_response)
+    return response
+
+
+def tag_account(
+    payload: Dict[str, Any],
+    account_info: Dict[str, str],
+    ct_management_session: Session,
+    rollback: bool,
+) -> None:
+    logger.info(payload)
+
+    tags = payload["account_request"]["account_tags"]
+    tag_list: List[TagTypeDef] = [{"Key": k, "Value": v} for k, v in tags.items()]
+
+    orgs_agent = OrganizationsAgent(ct_management_session)
+    orgs_agent.tag_org_resource(account_info["id"], tag_list, rollback)


### PR DESCRIPTION
## Problem

All AFT Lambda functions have been broken since April 11, preventing new AWS account creation. The `aft-account-request-action-trigger` Lambda crashes on startup with:

```
Runtime.ImportModuleError: Unable to import module 'aft_account_request_action_trigger':
cannot import name 'ProvisionRoles' from partially initialized module
'aft_common.account_provisioning_framework' (most likely due to a circular import)
```

## Root Cause

Commit 1d82b9d ("fix: remove Avodah customizations") accidentally overwrote `account_provisioning_framework.py` with the contents of `account_request_framework.py`. This:

1. Deleted the `ProvisionRoles` class (used by 11+ Lambda functions)
2. Introduced a circular self-import (`from aft_common.account_provisioning_framework import ProvisionRoles` in the same file)
3. Made the two files identical (confirmed via `diff`)

## Fix

Restore `account_provisioning_framework.py` from upstream, which correctly defines:
- `ProvisionRoles` class (`AWSAFTService` / `AWSAFTExecution` role management)
- `persist_metadata()`, `tag_account()`, `deploy_aws_aft_roles()`

## Impact

- **Blocked**: 4 new Med Registration accounts (dev/qa/stg/prod) from `aft-account-request` commit c0f4d6c
- **Broken since**: April 11 (layer version 2-8 all affected)
- **Last successful provisioning**: March 26

Once merged and deployed, the DynamoDB stream events should be reprocessed automatically (`MaximumRecordAgeInSeconds: -1`).